### PR TITLE
Add boss channel switch option

### DIFF
--- a/backend/src/database.rs
+++ b/backend/src/database.rs
@@ -164,6 +164,8 @@ pub struct Settings {
     #[serde(default = "enable_rune_solving_default")]
     pub enable_rune_solving: bool,
     #[serde(default)]
+    pub enable_meet_boss_switch_channel: bool,
+    #[serde(default)]
     pub enable_panic_mode: bool,
     #[serde(default)]
     pub panic_mode: PanicMode,
@@ -193,6 +195,7 @@ impl Default for Settings {
             id: None,
             capture_mode: CaptureMode::default(),
             enable_rune_solving: enable_rune_solving_default(),
+            enable_meet_boss_switch_channel: false,
             enable_panic_mode: false,
             panic_mode: PanicMode::default(),
             input_method: InputMethod::default(),

--- a/backend/src/request_handler.rs
+++ b/backend/src/request_handler.rs
@@ -137,6 +137,9 @@ impl DefaultRequestHandler<'_> {
             panic_mode: self.settings.panic_mode,
             enable_panic_mode: self.settings.enable_panic_mode,
             enable_rune_solving: self.settings.enable_rune_solving,
+            enable_meet_boss_switch_channel: self
+                .settings
+                .enable_meet_boss_switch_channel,
             enable_familiars_swapping: self.settings.familiars.enable_familiars_swapping,
             enable_reset_normal_actions_on_erda: reset_on_erda,
         };

--- a/backend/src/rotator.rs
+++ b/backend/src/rotator.rs
@@ -159,6 +159,7 @@ pub struct RotatorBuildArgs<'a> {
     pub panic_mode: PanicMode,
     pub enable_panic_mode: bool,
     pub enable_rune_solving: bool,
+    pub enable_meet_boss_switch_channel: bool,
     pub enable_familiars_swapping: bool,
     pub enable_reset_normal_actions_on_erda: bool,
 }
@@ -177,6 +178,7 @@ impl Rotator {
             panic_mode,
             enable_panic_mode,
             enable_rune_solving,
+            enable_meet_boss_switch_channel,
             enable_familiars_swapping,
             enable_reset_normal_actions_on_erda,
         } = args;
@@ -239,6 +241,12 @@ impl Rotator {
             self.priority_actions.insert(
                 self.id_counter.fetch_add(1, Ordering::Relaxed),
                 solve_rune_priority_action(),
+            );
+        }
+        if enable_meet_boss_switch_channel {
+            self.priority_actions.insert(
+                self.id_counter.fetch_add(1, Ordering::Relaxed),
+                elite_boss_switch_channel_priority_action(),
             );
         }
         if enable_familiars_swapping {
@@ -986,6 +994,32 @@ fn panic_priority_action(mode: PanicMode) -> PriorityAction {
 }
 
 #[inline]
+fn elite_boss_switch_channel_priority_action() -> PriorityAction {
+    PriorityAction {
+        condition: Condition(Box::new(|context, _, last_queued_time| {
+            if context.halting {
+                return ConditionResult::Ignore;
+            }
+            if !at_least_millis_passed_since(last_queued_time, 15000) {
+                return ConditionResult::Skip;
+            }
+            if let Minimap::Idle(idle) = context.minimap && idle.has_elite_boss {
+                ConditionResult::Queue
+            } else {
+                ConditionResult::Skip
+            }
+        })),
+        condition_kind: None,
+        inner: RotatorAction::Single(PlayerAction::Panic(PlayerActionPanic {
+            to: PanicTo::Channel,
+        })),
+        queue_to_front: true,
+        ignoring: false,
+        last_queued_time: None,
+    }
+}
+
+#[inline]
 fn at_least_millis_passed_since(last_queued_time: Option<Instant>, millis: u128) -> bool {
     last_queued_time
         .map(|instant| Instant::now().duration_since(instant).as_millis() >= millis)
@@ -1120,6 +1154,7 @@ mod tests {
             panic_mode: PanicMode::default(),
             enable_panic_mode: false,
             enable_rune_solving: true,
+            enable_meet_boss_switch_channel: false,
             enable_familiars_swapping: false,
             enable_reset_normal_actions_on_erda: false,
         };

--- a/ui/src/settings.rs
+++ b/ui/src/settings.rs
@@ -69,6 +69,16 @@ pub fn Settings(
                     value: settings_view().enable_rune_solving,
                 }
                 SettingsCheckbox {
+                    label: "Enable Meet Boss Switch Channel",
+                    on_input: move |enable_meet_boss_switch_channel| {
+                        on_settings(SettingsData {
+                            enable_meet_boss_switch_channel,
+                            ..settings_view.peek().clone()
+                        });
+                    },
+                    value: settings_view().enable_meet_boss_switch_channel,
+                }
+                SettingsCheckbox {
                     label: "Enable Panic Mode",
                     on_input: move |enable_panic_mode| {
                         on_settings(SettingsData {


### PR DESCRIPTION
## Summary
- introduce a new settings option `enable_meet_boss_switch_channel`
- add checkbox in UI below "Enable Rune Solving"
- switch channel automatically when elite boss is detected

## Testing
- `cargo fmt` *(failed: unsuccessful tunnel)*
- `cargo test --quiet` *(failed: unsuccessful tunnel)*
- `cargo check --quiet` *(failed: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684bd0d52ea083218f3ba2c994f544ac