### PR TITLE
feat: add rotator debug panel for observing queue and cooldown state

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -41,6 +41,8 @@ mod pathing;
 mod player;
 mod rng;
 mod rotator;
+#[cfg(debug_assertions)]
+mod rotator_debug;
 mod run;
 mod services;
 mod skill;
@@ -55,6 +57,12 @@ pub use {
     pathing::MAX_PLATFORMS_COUNT,
     run::init,
     strum::{EnumMessage, IntoEnumIterator, ParseError},
+};
+
+#[cfg(debug_assertions)]
+pub use rotator_debug::{
+    ActionView, BlockReason, CondOutcome, PriorityActionView, QueueKind, RotatorDebugEvent,
+    RotatorSnapshot,
 };
 
 type PendingRequest = (Request, Sender<Response>);
@@ -119,6 +127,10 @@ enum Request {
     #[cfg(debug_assertions)]
     DebugStateReceiver,
     #[cfg(debug_assertions)]
+    RotatorDebugReceiver,
+    #[cfg(debug_assertions)]
+    SetRotatorDebugEnabled(bool),
+    #[cfg(debug_assertions)]
     AutoSaveRune(bool),
     #[cfg(debug_assertions)]
     AutoRecordLieDetector(bool),
@@ -153,6 +165,10 @@ enum Response {
     SaveCaptureImage,
     #[cfg(debug_assertions)]
     DebugStateReceiver(broadcast::Receiver<DebugState>),
+    #[cfg(debug_assertions)]
+    RotatorDebugReceiver(broadcast::Receiver<Vec<RotatorDebugEvent>>),
+    #[cfg(debug_assertions)]
+    SetRotatorDebugEnabled,
     #[cfg(debug_assertions)]
     AutoSaveRune,
     #[cfg(debug_assertions)]
@@ -397,6 +413,16 @@ pub async fn save_capture_image(is_grayscale: bool) {
 #[cfg(debug_assertions)]
 pub async fn debug_state_receiver() -> broadcast::Receiver<DebugState> {
     send_request!(DebugStateReceiver => (receiver))
+}
+
+#[cfg(debug_assertions)]
+pub async fn rotator_debug_event_receiver() -> broadcast::Receiver<Vec<RotatorDebugEvent>> {
+    send_request!(RotatorDebugReceiver => (receiver))
+}
+
+#[cfg(debug_assertions)]
+pub async fn set_rotator_debug_enabled(enabled: bool) {
+    send_request!(SetRotatorDebugEnabled(enabled))
 }
 
 #[cfg(debug_assertions)]

--- a/backend/src/rotator.rs
+++ b/backend/src/rotator.rs
@@ -9,6 +9,12 @@ use std::{
     time::Instant,
 };
 
+#[cfg(debug_assertions)]
+use crate::rotator_debug::{
+    ActionView, BlockReason, CondOutcome, PriorityActionView, QueueKind, RotatorDebugEvent,
+    RotatorDebugSink, RotatorSnapshot,
+};
+
 use anyhow::Result;
 use log::{debug, info};
 #[cfg(test)]
@@ -184,6 +190,18 @@ pub trait Rotator: Debug + 'static {
     /// If [`Operation`] is currently halting, it does not rotate the built actions but only the
     /// side-loaded actions added by [`Self::inject_action`].
     fn rotate_action(&mut self, resources: &mut Resources, world: &mut World);
+
+    /// Enables or disables the debug event sink.
+    ///
+    /// When disabled the sink emits no events and has zero per-tick overhead.
+    #[cfg(debug_assertions)]
+    #[cfg_attr(test, concretize)]
+    fn set_debug_enabled(&mut self, enabled: bool);
+
+    /// Drains all pending debug events accumulated since the last call.
+    #[cfg(debug_assertions)]
+    #[cfg_attr(test, concretize)]
+    fn drain_debug_events(&mut self) -> Vec<RotatorDebugEvent>;
 }
 
 #[derive(Default, Debug)]
@@ -216,6 +234,11 @@ pub struct DefaultRotator {
     /// These are actions injected externally and to be executed as appropriate with the current
     /// [`Self::priority_actions_queue`]. These actions are run only once and do not have an ID.
     priority_actions_side_queue: VecDeque<RotatorAction>,
+
+    #[cfg(debug_assertions)]
+    sink: RotatorDebugSink,
+    #[cfg(debug_assertions)]
+    snapshot_needed: bool,
 }
 
 impl DefaultRotator {
@@ -372,11 +395,46 @@ impl DefaultRotator {
             };
             if action.queue_info.ignoring {
                 action.queue_info.last_queued_time = Some(Instant::now());
+                #[cfg(debug_assertions)]
+                {
+                    let av = debug_action_view_priority(id, action);
+                    let cr = debug_cooldown_remaining_ms(
+                        action.condition_kind,
+                        action.queue_info.last_queued_time,
+                    );
+                    let at = self.sink.now_ms();
+                    self.sink.emit(RotatorDebugEvent::ConditionEvaluated {
+                        at,
+                        action: av,
+                        outcome: CondOutcome::IgnoredWhileInQueue,
+                        cooldown_remaining_ms: cr,
+                    });
+                }
                 continue;
             }
 
             let condition_fn = &mut action.condition.0;
             let result = condition_fn(resources, world, &mut action.queue_info);
+            #[cfg(debug_assertions)]
+            {
+                let av = debug_action_view_priority(id, action);
+                let outcome = match result {
+                    ConditionResult::Queue => CondOutcome::Queue,
+                    ConditionResult::Skip => CondOutcome::Skip,
+                    ConditionResult::Ignore => CondOutcome::Ignore,
+                };
+                let cr = debug_cooldown_remaining_ms(
+                    action.condition_kind,
+                    action.queue_info.last_queued_time,
+                );
+                let at = self.sink.now_ms();
+                self.sink.emit(RotatorDebugEvent::ConditionEvaluated {
+                    at,
+                    action: av,
+                    outcome,
+                    cooldown_remaining_ms: cr,
+                });
+            }
             match result {
                 ConditionResult::Queue => {
                     let conflict = if let Some(metadata) = action.metadata {
@@ -396,6 +454,20 @@ impl DefaultRotator {
                                 self.priority_actions_queue.push_back(id);
                             }
                             action.queue_info.last_queued_time = Some(Instant::now());
+                            #[cfg(debug_assertions)]
+                            {
+                                let av = debug_action_view_priority(id, action);
+                                let to_front = action.queue_to_front;
+                                let queue_len = self.priority_actions_queue.len();
+                                let at = self.sink.now_ms();
+                                self.sink.emit(RotatorDebugEvent::Enqueued {
+                                    at,
+                                    kind: QueueKind::Priority,
+                                    action: av,
+                                    queue_len,
+                                    to_front,
+                                });
+                            }
 
                             if !did_queue_erda_action {
                                 did_queue_erda_action = matches!(
@@ -486,10 +558,36 @@ impl DefaultRotator {
         if !player
             .state
             .can_override_current_state(player.context.last_known_pos)
-            || has_normal_linked_action_queuing_or_executing(self, &player.context)
-            || has_priority_linked_action_executing(self, &player.context)
-            || has_side_loaded_action_executing(&player.context)
         {
+            #[cfg(debug_assertions)]
+            self.sink.emit(RotatorDebugEvent::Blocked {
+                at: self.sink.now_ms(),
+                reason: BlockReason::CannotOverrideCurrentState,
+            });
+            return;
+        }
+        if has_normal_linked_action_queuing_or_executing(self, &player.context) {
+            #[cfg(debug_assertions)]
+            self.sink.emit(RotatorDebugEvent::Blocked {
+                at: self.sink.now_ms(),
+                reason: BlockReason::NormalLinkedActionActive,
+            });
+            return;
+        }
+        if has_priority_linked_action_executing(self, &player.context) {
+            #[cfg(debug_assertions)]
+            self.sink.emit(RotatorDebugEvent::Blocked {
+                at: self.sink.now_ms(),
+                reason: BlockReason::PriorityLinkedActionExecuting,
+            });
+            return;
+        }
+        if has_side_loaded_action_executing(&player.context) {
+            #[cfg(debug_assertions)]
+            self.sink.emit(RotatorDebugEvent::Blocked {
+                at: self.sink.now_ms(),
+                reason: BlockReason::SideLoadedActionExecuting,
+            });
             return;
         }
 
@@ -510,6 +608,11 @@ impl DefaultRotator {
             })
             .unwrap_or_default();
         if player_has_queue_to_front {
+            #[cfg(debug_assertions)]
+            self.sink.emit(RotatorDebugEvent::Blocked {
+                at: self.sink.now_ms(),
+                reason: BlockReason::QueueToFrontHeld,
+            });
             return;
         }
 
@@ -523,6 +626,9 @@ impl DefaultRotator {
         let Some(action) = self.priority_actions.get(&id) else {
             return;
         };
+
+        #[cfg(debug_assertions)]
+        let (debug_av, debug_at) = (debug_action_view_priority(id, action), self.sink.now_ms());
 
         match action.inner.clone() {
             RotatorAction::Single(inner) => {
@@ -544,6 +650,13 @@ impl DefaultRotator {
                 self.rotate_queuing_linked_action(&mut player.context, true);
             }
         }
+
+        #[cfg(debug_assertions)]
+        self.sink.emit(RotatorDebugEvent::Dispatched {
+            at: debug_at,
+            kind: QueueKind::Priority,
+            action: debug_av,
+        });
     }
 
     fn rotate_auto_mobbing(
@@ -723,6 +836,18 @@ impl DefaultRotator {
 
         debug_assert!(self.normal_index < self.normal_actions.len());
         let (id, action) = self.normal_actions[self.normal_index].clone();
+        #[cfg(debug_assertions)]
+        let (debug_av, debug_at) = (
+            ActionView {
+                id: Some(id),
+                label: debug_action_inner_label(&action),
+                condition_kind: "Any".to_string(),
+                queue_to_front: false,
+            },
+            self.sink.now_ms(),
+        );
+        #[cfg(debug_assertions)]
+        let debug_index = self.normal_index;
         self.normal_index = (self.normal_index + 1) % self.normal_actions.len();
         match action {
             RotatorAction::Single(action) => {
@@ -733,6 +858,13 @@ impl DefaultRotator {
                 self.rotate_queuing_linked_action(player_context, false);
             }
         }
+        #[cfg(debug_assertions)]
+        self.sink.emit(RotatorDebugEvent::NormalAdvanced {
+            at: debug_at,
+            index: debug_index,
+            backward: false,
+            action: debug_av,
+        });
     }
 
     fn rotate_start_to_end_then_reverse(&mut self, player_context: &mut PlayerContext) {
@@ -757,6 +889,18 @@ impl DefaultRotator {
             self.normal_index
         };
         let (id, action) = self.normal_actions[i].clone();
+        #[cfg(debug_assertions)]
+        let (debug_av, debug_at, debug_backward, debug_index) = (
+            ActionView {
+                id: Some(id),
+                label: debug_action_inner_label(&action),
+                condition_kind: "Any".to_string(),
+                queue_to_front: false,
+            },
+            self.sink.now_ms(),
+            self.normal_actions_backward,
+            i,
+        );
 
         self.normal_index = (self.normal_index + 1) % len;
         match action {
@@ -768,6 +912,13 @@ impl DefaultRotator {
                 self.rotate_queuing_linked_action(player_context, false);
             }
         }
+        #[cfg(debug_assertions)]
+        self.sink.emit(RotatorDebugEvent::NormalAdvanced {
+            at: debug_at,
+            index: debug_index,
+            backward: debug_backward,
+            action: debug_av,
+        });
     }
 
     #[inline]
@@ -798,16 +949,85 @@ impl DefaultRotator {
     fn rotate_side_priority_action(&mut self, player_context: &mut PlayerContext) -> bool {
         if let Some(action) = self.priority_actions_side_queue.pop_front() {
             debug_assert!(!player_context.has_priority_action());
+            #[cfg(debug_assertions)]
+            let debug_av = ActionView {
+                id: None,
+                label: debug_action_inner_label(&action),
+                condition_kind: "None".to_string(),
+                queue_to_front: false,
+            };
+            #[cfg(debug_assertions)]
+            let debug_at = self.sink.now_ms();
             match action {
                 RotatorAction::Single(action) => {
                     player_context.set_priority_action(None, action);
                 }
                 RotatorAction::Linked(_) => unreachable!(),
             }
+            #[cfg(debug_assertions)]
+            self.sink.emit(RotatorDebugEvent::Dispatched {
+                at: debug_at,
+                kind: QueueKind::Side,
+                action: debug_av,
+            });
             return true;
         }
 
         false
+    }
+
+    #[cfg(debug_assertions)]
+    fn build_snapshot(&self) -> RotatorSnapshot {
+        let at = self.sink.now_ms();
+
+        let priority_queue: Vec<ActionView> = self
+            .priority_actions_queue
+            .iter()
+            .filter_map(|id| {
+                self.priority_actions
+                    .get(id)
+                    .map(|a| debug_action_view_priority(*id, a))
+            })
+            .collect();
+
+        let normal_actions: Vec<ActionView> = self
+            .normal_actions
+            .iter()
+            .map(|(id, action)| ActionView {
+                id: Some(*id),
+                label: debug_action_inner_label(action),
+                condition_kind: "Any".to_string(),
+                queue_to_front: false,
+            })
+            .collect();
+
+        let priority_actions: Vec<PriorityActionView> = self
+            .priority_actions
+            .iter()
+            .map(|(id, action)| {
+                let in_queue = self.priority_actions_queue.contains(id);
+                PriorityActionView {
+                    action: debug_action_view_priority(*id, action),
+                    ignoring: action.queue_info.ignoring,
+                    cooldown_remaining_ms: debug_cooldown_remaining_ms(
+                        action.condition_kind,
+                        action.queue_info.last_queued_time,
+                    ),
+                    in_queue_or_executing: in_queue,
+                }
+            })
+            .collect();
+
+        RotatorSnapshot {
+            at,
+            priority_queue,
+            side_queue_len: self.priority_actions_side_queue.len(),
+            normal_index: self.normal_index,
+            normal_backward: self.normal_actions_backward,
+            normal_actions,
+            priority_actions,
+            player_block_reason: BlockReason::None,
+        }
     }
 }
 
@@ -978,12 +1198,34 @@ impl Rotator for DefaultRotator {
 
     #[inline]
     fn inject_action(&mut self, action: PlayerAction) {
+        #[cfg(debug_assertions)]
+        let debug_av = ActionView {
+            id: None,
+            label: debug_action_inner_label(&RotatorAction::Single(action.clone())),
+            condition_kind: "None".to_string(),
+            queue_to_front: false,
+        };
         self.priority_actions_side_queue
             .push_back(RotatorAction::Single(action));
+        #[cfg(debug_assertions)]
+        self.sink.emit(RotatorDebugEvent::Enqueued {
+            at: self.sink.now_ms(),
+            kind: QueueKind::Side,
+            action: debug_av,
+            queue_len: self.priority_actions_side_queue.len(),
+            to_front: false,
+        });
     }
 
     #[inline]
     fn rotate_action(&mut self, resources: &mut Resources, world: &mut World) {
+        #[cfg(debug_assertions)]
+        if self.snapshot_needed && self.sink.enabled {
+            let snap = self.build_snapshot();
+            self.sink.emit(RotatorDebugEvent::Snapshot(snap));
+            self.snapshot_needed = false;
+        }
+
         if resources.operation.halting() {
             if !has_side_loaded_action_executing(&world.player.context) {
                 self.rotate_side_priority_action(&mut world.player.context);
@@ -1011,11 +1253,93 @@ impl Rotator for DefaultRotator {
             }
         }
     }
+
+    #[cfg(debug_assertions)]
+    fn set_debug_enabled(&mut self, enabled: bool) {
+        self.sink.set_enabled(enabled);
+        if enabled {
+            self.snapshot_needed = true;
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    fn drain_debug_events(&mut self) -> Vec<RotatorDebugEvent> {
+        if !self.sink.dirty {
+            return Vec::new();
+        }
+        self.sink.drain_pending()
+    }
 }
 
 #[inline]
 fn has_side_loaded_action_executing(player_context: &PlayerContext) -> bool {
     player_context.has_priority_action() && player_context.priority_action_id().is_none()
+}
+
+// ---------------------------------------------------------------------------
+// Debug helpers (compiled only in debug builds)
+// ---------------------------------------------------------------------------
+
+#[cfg(debug_assertions)]
+fn debug_action_inner_label(action: &RotatorAction) -> String {
+    match action {
+        RotatorAction::Single(pa) => match pa {
+            PlayerAction::SolveRune => "SolveRune".to_string(),
+            PlayerAction::SolveShape => "SolveShape".to_string(),
+            PlayerAction::SolveVioletta => "SolveVioletta".to_string(),
+            PlayerAction::FamiliarsSwap(_) => "FamiliarsSwap".to_string(),
+            PlayerAction::Panic(_) => "Panic".to_string(),
+            PlayerAction::UseBooster(b) => format!("UseBooster({:?})", b.kind),
+            PlayerAction::ExchangeBooster(_) => "ExchangeBooster".to_string(),
+            PlayerAction::Unstuck => "Unstuck".to_string(),
+            PlayerAction::AutoMob(_) => "AutoMob".to_string(),
+            PlayerAction::PingPong(_) => "PingPong".to_string(),
+            PlayerAction::Key(k) => format!("Key({:?})", k.key),
+            PlayerAction::Move(m) => format!("Move({},{})", m.position.x, m.position.y),
+        },
+        RotatorAction::Linked(la) => {
+            format!(
+                "Linked({})",
+                debug_action_inner_label(&RotatorAction::Single(la.inner.clone()))
+            )
+        }
+    }
+}
+
+#[cfg(debug_assertions)]
+fn debug_action_view_priority(id: u32, action: &PriorityAction) -> ActionView {
+    let label = match action.metadata {
+        Some(ActionMetadata::Buff { kind }) => format!("Buff({kind:?})"),
+        Some(ActionMetadata::UseBooster) => "UseBooster".to_string(),
+        None => debug_action_inner_label(&action.inner),
+    };
+    ActionView {
+        id: Some(id),
+        label,
+        condition_kind: action
+            .condition_kind
+            .map(|c| format!("{c}"))
+            .unwrap_or_else(|| "None".to_string()),
+        queue_to_front: action.queue_to_front,
+    }
+}
+
+/// Returns `target_ms - elapsed_since_last_queued`, negative means ready.
+/// Returns `None` for conditions without cooldown semantics.
+#[cfg(debug_assertions)]
+fn debug_cooldown_remaining_ms(
+    condition_kind: Option<ActionCondition>,
+    last_queued_time: Option<std::time::Instant>,
+) -> Option<i64> {
+    let target_ms: i64 = match condition_kind {
+        Some(ActionCondition::EveryMillis(n)) => n as i64,
+        Some(ActionCondition::ErdaShowerOffCooldown) => 20_000,
+        _ => return None,
+    };
+    let elapsed_ms = last_queued_time
+        .map(|t| t.elapsed().as_millis() as i64)
+        .unwrap_or(target_ms);
+    Some(target_ms - elapsed_ms)
 }
 
 /// Creates a [`RotatorAction`] with `start_action` as the initial action

--- a/backend/src/rotator_debug.rs
+++ b/backend/src/rotator_debug.rs
@@ -1,0 +1,186 @@
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+
+/// Elapsed milliseconds since the rotator was started, used as a time axis for the UI.
+pub type ElapsedMs = u64;
+
+/// Which of the three queues an action belongs to.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum QueueKind {
+    /// `priority_actions_queue`
+    Priority,
+    /// `priority_actions_side_queue` (one-shot injected actions)
+    Side,
+    /// Normal traversal (StartToEnd / Reverse / AutoMobbing / PingPong)
+    Normal,
+}
+
+/// Lightweight identifier for an action shown in the UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActionView {
+    /// Priority/normal action id; `None` for side-queue actions without an id.
+    pub id: Option<u32>,
+    /// Human-readable label, e.g. `"Buff(Rune)"`, `"ErdaShower"`, `"SolveRune"`.
+    pub label: String,
+    /// Stringified condition kind, e.g. `"EveryMillis(30000)"`.
+    pub condition_kind: String,
+    /// Whether the action was queued to the front.
+    pub queue_to_front: bool,
+}
+
+/// Result of evaluating an action's condition this tick.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum CondOutcome {
+    Queue,
+    Skip,
+    Ignore,
+    /// Condition was not called because `ignoring == true`.
+    IgnoredWhileInQueue,
+}
+
+/// Why the priority queue dispatch was blocked this tick.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub enum BlockReason {
+    #[default]
+    None,
+    CannotOverrideCurrentState,
+    NormalLinkedActionActive,
+    PriorityLinkedActionExecuting,
+    SideLoadedActionExecuting,
+    QueueToFrontHeld,
+}
+
+/// A single debug event emitted by the rotator.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum RotatorDebugEvent {
+    /// An action's condition was evaluated (or skipped because `ignoring`).
+    ConditionEvaluated {
+        at: ElapsedMs,
+        action: ActionView,
+        outcome: CondOutcome,
+        /// Milliseconds until the action can be queued again (>0 = on cooldown).
+        /// `None` when the condition has no cooldown semantics.
+        cooldown_remaining_ms: Option<i64>,
+    },
+    /// An action was pushed into a queue.
+    Enqueued {
+        at: ElapsedMs,
+        kind: QueueKind,
+        action: ActionView,
+        /// Queue length after the push.
+        queue_len: usize,
+        to_front: bool,
+    },
+    /// An action was handed to the player for execution.
+    Dispatched {
+        at: ElapsedMs,
+        kind: QueueKind,
+        action: ActionView,
+    },
+    /// The priority dispatch was blocked this tick.
+    Blocked {
+        at: ElapsedMs,
+        reason: BlockReason,
+    },
+    /// Normal traversal advanced to a new index.
+    NormalAdvanced {
+        at: ElapsedMs,
+        index: usize,
+        backward: bool,
+        action: ActionView,
+    },
+    /// Full snapshot sent on first connection or refresh.
+    Snapshot(RotatorSnapshot),
+}
+
+/// Full state snapshot for initial display or manual refresh.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RotatorSnapshot {
+    pub at: ElapsedMs,
+    pub priority_queue: Vec<ActionView>,
+    pub side_queue_len: usize,
+    pub normal_index: usize,
+    pub normal_backward: bool,
+    pub normal_actions: Vec<ActionView>,
+    pub priority_actions: Vec<PriorityActionView>,
+    pub player_block_reason: BlockReason,
+}
+
+/// Per-priority-action view for the condition/cooldown panel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PriorityActionView {
+    pub action: ActionView,
+    pub ignoring: bool,
+    /// Milliseconds until the action can be queued again.
+    pub cooldown_remaining_ms: Option<i64>,
+    pub in_queue_or_executing: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Sink
+// ---------------------------------------------------------------------------
+
+/// Ring-buffer event collector owned by `DefaultRotator`.
+#[derive(Debug)]
+pub struct RotatorDebugSink {
+    pub enabled: bool,
+    history: VecDeque<RotatorDebugEvent>,
+    capacity: usize,
+    started: Instant,
+    /// Whether new events have been pushed since the last `drain_pending` call.
+    pub dirty: bool,
+}
+
+impl Default for RotatorDebugSink {
+    fn default() -> Self {
+        Self::new(512)
+    }
+}
+
+impl RotatorDebugSink {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            enabled: false,
+            history: VecDeque::with_capacity(capacity),
+            capacity,
+            started: Instant::now(),
+            dirty: false,
+        }
+    }
+
+    #[inline]
+    pub fn now_ms(&self) -> ElapsedMs {
+        self.started.elapsed().as_millis() as ElapsedMs
+    }
+
+    #[inline]
+    pub fn set_enabled(&mut self, on: bool) {
+        self.enabled = on;
+        if !on {
+            self.dirty = false;
+            self.history.clear();
+        }
+    }
+
+    /// Emits an event. No-op when disabled.
+    #[inline]
+    pub fn emit(&mut self, ev: RotatorDebugEvent) {
+        if !self.enabled {
+            return;
+        }
+        if self.history.len() == self.capacity {
+            self.history.pop_front();
+        }
+        self.history.push_back(ev);
+        self.dirty = true;
+    }
+
+    /// Returns all pending events and clears the dirty flag.
+    /// The history itself is **not** cleared so a subsequent `Snapshot` can still be built.
+    pub fn drain_pending(&mut self) -> Vec<RotatorDebugEvent> {
+        self.dirty = false;
+        self.history.iter().cloned().collect()
+    }
+}

--- a/backend/src/services/debug.rs
+++ b/backend/src/services/debug.rs
@@ -26,12 +26,13 @@ use tokio::{
 };
 
 use crate::{
-    DebugState, TransparentShapeDifficulty,
+    DebugState, RotatorDebugEvent, TransparentShapeDifficulty,
     bridge::{Input, MouseKind},
     detect::DefaultDetector,
     ecs::Resources,
     mat::OwnedMat,
     models::Localization,
+    rotator::Rotator,
     run::FPS,
     solvers::{RuneSolver, TransparentShapeSolver, ViolettaSolver},
     utils::DatasetDir,
@@ -40,6 +41,7 @@ use crate::{
 #[derive(Debug)]
 pub struct DebugService {
     state: Sender<DebugState>,
+    rotator_events: Sender<Vec<RotatorDebugEvent>>,
     writer: Option<VideoWriter>,
 }
 
@@ -47,6 +49,7 @@ impl Default for DebugService {
     fn default() -> Self {
         Self {
             state: broadcast::channel(1).0,
+            rotator_events: broadcast::channel(16).0,
             writer: None,
         }
     }
@@ -71,6 +74,22 @@ impl DebugService {
 
     pub fn subscribe_state(&self) -> Receiver<DebugState> {
         self.state.subscribe()
+    }
+
+    pub fn subscribe_rotator_events(&self) -> Receiver<Vec<RotatorDebugEvent>> {
+        self.rotator_events.subscribe()
+    }
+
+    /// Drains pending debug events from the rotator and broadcasts them.
+    /// No-op when there are no active subscribers or the sink is not dirty.
+    pub fn broadcast_rotator_debug(&self, rotator: &mut dyn Rotator) {
+        if self.rotator_events.receiver_count() == 0 {
+            return;
+        }
+        let events = rotator.drain_debug_events();
+        if !events.is_empty() {
+            let _ = self.rotator_events.send(events);
+        }
     }
 
     pub fn record_video(&mut self, resources: &mut Resources, start: bool) {

--- a/backend/src/services/mediator.rs
+++ b/backend/src/services/mediator.rs
@@ -217,6 +217,15 @@ fn handle_ui_request(
         #[cfg(debug_assertions)]
         Request::DebugStateReceiver => Response::DebugStateReceiver(subscribe_debug_state(context)),
         #[cfg(debug_assertions)]
+        Request::RotatorDebugReceiver => {
+            Response::RotatorDebugReceiver(context.debug_service.subscribe_rotator_events())
+        }
+        #[cfg(debug_assertions)]
+        Request::SetRotatorDebugEnabled(enabled) => {
+            context.rotator.set_debug_enabled(enabled);
+            Response::SetRotatorDebugEnabled
+        }
+        #[cfg(debug_assertions)]
         Request::AutoSaveRune(auto_save) => {
             context.resources.debug.auto_save_rune = auto_save;
             Response::AutoSaveRune

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -239,6 +239,8 @@ impl Services {
 
         #[cfg(debug_assertions)]
         self.debug.poll(resources);
+        #[cfg(debug_assertions)]
+        self.debug.broadcast_rotator_debug(rotator);
         self.mediator.broadcast_state(resources, world);
     }
 }

--- a/ui/src/debug.rs
+++ b/ui/src/debug.rs
@@ -1,6 +1,8 @@
 use backend::{
-    DebugState, TransparentShapeDifficulty, auto_record_lie_detector, auto_save_rune,
-    debug_state_receiver, record_video, test_spin_rune, test_transparent_shape, test_violetta,
+    ActionView, BlockReason, CondOutcome, DebugState, PriorityActionView, QueueKind,
+    RotatorDebugEvent, RotatorSnapshot, TransparentShapeDifficulty, auto_record_lie_detector,
+    auto_save_rune, debug_state_receiver, record_video, rotator_debug_event_receiver,
+    set_rotator_debug_enabled, test_spin_rune, test_transparent_shape, test_violetta,
 };
 use dioxus::prelude::*;
 use tokio::sync::broadcast::error::RecvError;
@@ -103,6 +105,425 @@ pub fn DebugScreen() -> Element {
                     }
                 }
             }
+        }
+        RotatorDebugPanel {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rotator Debug Panel
+// ---------------------------------------------------------------------------
+
+/// Local UI state rebuilt from incoming events.
+#[derive(Default, Clone)]
+struct RotatorDebugState {
+    priority_queue: Vec<ActionView>,
+    side_queue_len: usize,
+    normal_index: usize,
+    normal_backward: bool,
+    normal_actions: Vec<ActionView>,
+    priority_actions: Vec<PriorityActionView>,
+    player_block_reason: BlockReason,
+    timeline: Vec<TimelineEntry>,
+    enabled: bool,
+    paused: bool,
+}
+
+#[derive(Clone)]
+struct TimelineEntry {
+    at_ms: u64,
+    text: String,
+    is_warn: bool,
+}
+
+
+impl RotatorDebugState {
+    fn apply_event(&mut self, ev: &RotatorDebugEvent) {
+        match ev {
+            RotatorDebugEvent::Snapshot(snap) => {
+                self.priority_queue = snap.priority_queue.clone();
+                self.side_queue_len = snap.side_queue_len;
+                self.normal_index = snap.normal_index;
+                self.normal_backward = snap.normal_backward;
+                self.normal_actions = snap.normal_actions.clone();
+                self.priority_actions = snap.priority_actions.clone();
+                self.player_block_reason = snap.player_block_reason.clone();
+            }
+            RotatorDebugEvent::Enqueued {
+                at,
+                kind,
+                action,
+                queue_len,
+                to_front,
+            } => {
+                let text = format!(
+                    "{:.2}s  Enqueued  {:?}  {}  (len={}) {}",
+                    *at as f64 / 1000.0,
+                    kind,
+                    action.label,
+                    queue_len,
+                    if *to_front { "[front]" } else { "" }
+                );
+                self.push_timeline(TimelineEntry {
+                    at_ms: *at,
+                    text,
+                    is_warn: false,
+                });
+                match kind {
+                    QueueKind::Priority => {
+                        if *to_front {
+                            self.priority_queue.insert(0, action.clone());
+                        } else {
+                            self.priority_queue.push(action.clone());
+                        }
+                    }
+                    QueueKind::Side => {
+                        self.side_queue_len += 1;
+                    }
+                    QueueKind::Normal => {}
+                }
+            }
+            RotatorDebugEvent::Dispatched { at, kind, action } => {
+                let text = format!(
+                    "{:.2}s  Dispatched  {:?}  {}",
+                    *at as f64 / 1000.0,
+                    kind,
+                    action.label
+                );
+                self.push_timeline(TimelineEntry {
+                    at_ms: *at,
+                    text,
+                    is_warn: false,
+                });
+                match kind {
+                    QueueKind::Priority => {
+                        self.priority_queue.retain(|a| a.label != action.label);
+                    }
+                    QueueKind::Side => {
+                        self.side_queue_len = self.side_queue_len.saturating_sub(1);
+                    }
+                    QueueKind::Normal => {}
+                }
+            }
+            RotatorDebugEvent::Blocked { at, reason } => {
+                self.player_block_reason = reason.clone();
+                let text = format!(
+                    "{:.2}s  Blocked  {:?}",
+                    *at as f64 / 1000.0,
+                    reason
+                );
+                self.push_timeline(TimelineEntry {
+                    at_ms: *at,
+                    text,
+                    is_warn: false,
+                });
+            }
+            RotatorDebugEvent::ConditionEvaluated {
+                at,
+                action,
+                outcome,
+                cooldown_remaining_ms,
+            } => {
+                let is_warn = matches!(outcome, CondOutcome::IgnoredWhileInQueue);
+                if is_warn {
+                    let cooldown_str = cooldown_remaining_ms
+                        .map(|ms| {
+                            if ms <= 0 {
+                                "ready".to_string()
+                            } else {
+                                format!("{:.1}s", ms as f64 / 1000.0)
+                            }
+                        })
+                        .unwrap_or_default();
+                    let text = format!(
+                        "{:.2}s  IgnoredWhileInQueue  {}  cooldown={}",
+                        *at as f64 / 1000.0,
+                        action.label,
+                        cooldown_str
+                    );
+                    self.push_timeline(TimelineEntry {
+                        at_ms: *at,
+                        text,
+                        is_warn: true,
+                    });
+                }
+                // Update the cooldown info in priority_actions view
+                if let Some(pav) = self
+                    .priority_actions
+                    .iter_mut()
+                    .find(|p| p.action.id == action.id)
+                {
+                    pav.ignoring = matches!(outcome, CondOutcome::IgnoredWhileInQueue);
+                    pav.cooldown_remaining_ms = *cooldown_remaining_ms;
+                }
+            }
+            RotatorDebugEvent::NormalAdvanced {
+                index, backward, ..
+            } => {
+                self.normal_index = *index;
+                self.normal_backward = *backward;
+            }
+        }
+    }
+
+    fn push_timeline(&mut self, entry: TimelineEntry) {
+        const MAX_TIMELINE: usize = 200;
+        if self.timeline.len() >= MAX_TIMELINE {
+            self.timeline.remove(0);
+        }
+        self.timeline.push(entry);
+    }
+}
+
+#[component]
+pub fn RotatorDebugPanel() -> Element {
+    let mut debug = use_signal(RotatorDebugState::default);
+
+    use_future(move || async move {
+        let mut rx = rotator_debug_event_receiver().await;
+        loop {
+            let events = match rx.recv().await {
+                Ok(events) => events,
+                Err(RecvError::Closed) => break,
+                Err(RecvError::Lagged(_)) => continue,
+            };
+            let is_paused = debug.peek().paused;
+            debug.with_mut(|d| {
+                for ev in &events {
+                    // Always apply to state; timeline is gated on pause below
+                    match ev {
+                        RotatorDebugEvent::ConditionEvaluated { .. }
+                        | RotatorDebugEvent::Enqueued { .. }
+                        | RotatorDebugEvent::Dispatched { .. }
+                        | RotatorDebugEvent::Blocked { .. }
+                        | RotatorDebugEvent::NormalAdvanced { .. }
+                        | RotatorDebugEvent::Snapshot(_) => {
+                            if is_paused {
+                                // Still update structural state but skip timeline push
+                                match ev {
+                                    RotatorDebugEvent::Snapshot(snap) => {
+                                        d.priority_queue = snap.priority_queue.clone();
+                                        d.side_queue_len = snap.side_queue_len;
+                                        d.normal_index = snap.normal_index;
+                                        d.normal_backward = snap.normal_backward;
+                                        d.normal_actions = snap.normal_actions.clone();
+                                        d.priority_actions = snap.priority_actions.clone();
+                                        d.player_block_reason = snap.player_block_reason.clone();
+                                    }
+                                    RotatorDebugEvent::NormalAdvanced { index, backward, .. } => {
+                                        d.normal_index = *index;
+                                        d.normal_backward = *backward;
+                                    }
+                                    _ => {}
+                                }
+                            } else {
+                                d.apply_event(ev);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+
+    let enabled = debug.read().enabled;
+    let paused = debug.read().paused;
+
+    rsx! {
+        Section { title: "Rotator Debug",
+            // Controls row
+            div { class: "flex gap-2 mb-2",
+                Button {
+                    style: if enabled { ButtonStyle::Primary } else { ButtonStyle::Secondary },
+                    on_click: move |_| async move {
+                        let new_enabled = !debug.peek().enabled;
+                        set_rotator_debug_enabled(new_enabled).await;
+                        debug.with_mut(|d| {
+                            d.enabled = new_enabled;
+                            if !new_enabled {
+                                *d = RotatorDebugState::default();
+                            }
+                        });
+                    },
+                    if enabled { "Disable" } else { "Enable" }
+                }
+                Button {
+                    style: if paused { ButtonStyle::Primary } else { ButtonStyle::Secondary },
+                    on_click: move |_| {
+                        debug.with_mut(|d| d.paused = !d.paused);
+                    },
+                    if paused { "Resume" } else { "Pause" }
+                }
+            }
+
+            if enabled {
+                // ① Queues
+                div { class: "mb-3",
+                    div { class: "text-xs text-primary-text font-medium mb-1", "① Queues" }
+                    div { class: "flex gap-3 flex-wrap",
+                        // Priority queue
+                        div { class: "flex-1 min-w-32",
+                            div { class: "text-xs text-secondary-text font-medium mb-1", "Priority" }
+                            div { class: "bg-secondary-surface p-2 min-h-8 text-xs font-mono",
+                                if debug.read().priority_queue.is_empty() {
+                                    span { class: "text-tertiary-text", "(empty)" }
+                                } else {
+                                    for av in debug.read().priority_queue.clone() {
+                                        div {
+                                            key: "{av.label}",
+                                            class: "truncate",
+                                            if av.queue_to_front {
+                                                span { class: "text-yellow-400 mr-1", "▶" }
+                                            }
+                                            {av.id.map(|id| format!("#{id} ")).unwrap_or_default()}
+                                            {av.label.clone()}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // Side queue
+                        div { class: "flex-1 min-w-24",
+                            div { class: "text-xs text-secondary-text font-medium mb-1", "Side" }
+                            div { class: "bg-secondary-surface p-2 min-h-8 text-xs font-mono",
+                                if debug.read().side_queue_len == 0 {
+                                    span { class: "text-tertiary-text", "(empty)" }
+                                } else {
+                                    span { "{debug.read().side_queue_len} pending" }
+                                }
+                            }
+                        }
+                        // Normal traversal
+                        div { class: "flex-1 min-w-40",
+                            div { class: "text-xs text-secondary-text font-medium mb-1",
+                                "Normal (idx {debug.read().normal_index}"
+                                if debug.read().normal_backward {
+                                    " ←rev"
+                                }
+                                ")"
+                            }
+                            div { class: "bg-secondary-surface p-2 min-h-8 text-xs font-mono flex flex-wrap gap-1",
+                                for (i, av) in debug.read().normal_actions.clone().into_iter().enumerate() {
+                                    span {
+                                        key: "{i}",
+                                        class: if i == debug.read().normal_index {
+                                            "bg-primary-surface text-primary-text px-1"
+                                        } else {
+                                            "text-secondary-text px-1"
+                                        },
+                                        "{i}:{av.label}"
+                                    }
+                                }
+                                if debug.read().normal_actions.is_empty() {
+                                    span { class: "text-tertiary-text", "(empty)" }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ② Conditions & Cooldown
+                div { class: "mb-3",
+                    div { class: "text-xs text-primary-text font-medium mb-1", "② Conditions & Cooldown" }
+                    div { class: "bg-secondary-surface p-2",
+                        if debug.read().priority_actions.is_empty() {
+                            div { class: "text-xs text-tertiary-text", "(no priority actions)" }
+                        } else {
+                            for pav in debug.read().priority_actions.clone() {
+                                div {
+                                    key: "{pav.action.label}",
+                                    class: "flex items-center gap-2 mb-1 text-xs",
+                                    // Label
+                                    span { class: "w-40 truncate font-mono", "{pav.action.label}" }
+                                    // Ignoring badge
+                                    span {
+                                        class: if pav.ignoring {
+                                            "text-yellow-400 w-16 text-center"
+                                        } else {
+                                            "text-tertiary-text w-16 text-center"
+                                        },
+                                        if pav.ignoring { "ignoring:✓" } else { "ignoring:✗" }
+                                    }
+                                    // Cooldown bar + label
+                                    {render_cooldown(pav.cooldown_remaining_ms, pav.action.condition_kind.as_str())}
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // ③ Timeline
+                div { class: "mb-3",
+                    div { class: "text-xs text-primary-text font-medium mb-1", "③ Timeline" }
+                    div {
+                        class: "bg-secondary-surface p-2 h-40 overflow-y-auto font-mono text-xs",
+                        id: "rotator-timeline",
+                        for (i, entry) in debug.read().timeline.clone().into_iter().enumerate() {
+                            div {
+                                key: "{i}",
+                                class: if entry.is_warn {
+                                    "text-yellow-400"
+                                } else {
+                                    "text-secondary-text"
+                                },
+                                "{entry.text}"
+                            }
+                        }
+                    }
+                }
+
+                // ④ Player State
+                div {
+                    div { class: "text-xs text-primary-text font-medium mb-1", "④ Player State" }
+                    div { class: "bg-secondary-surface p-2 text-xs font-mono",
+                        "block: {debug.read().player_block_reason:?}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn render_cooldown(remaining_ms: Option<i64>, condition_kind: &str) -> Element {
+    let Some(remaining) = remaining_ms else {
+        return rsx! {
+            span { class: "text-tertiary-text text-xs", "{condition_kind}" }
+        };
+    };
+
+    let total_ms: i64 = if condition_kind.starts_with("EveryMillis") {
+        condition_kind
+            .trim_start_matches("EveryMillis(")
+            .trim_end_matches(')')
+            .parse()
+            .unwrap_or(30_000)
+    } else if condition_kind == "ErdaShowerOffCooldown" {
+        20_000
+    } else {
+        return rsx! {
+            span { class: "text-tertiary-text text-xs", "{condition_kind}" }
+        };
+    };
+
+    if remaining <= 0 {
+        return rsx! {
+            span { class: "text-green-400 text-xs font-medium", "可排入" }
+        };
+    }
+
+    let pct = ((total_ms - remaining) as f64 / total_ms as f64 * 100.0)
+        .clamp(0.0, 100.0) as u32;
+    let secs = remaining as f64 / 1000.0;
+
+    rsx! {
+        div { class: "flex items-center gap-1 flex-1",
+            div { class: "flex-1 h-2 bg-tertiary-surface rounded overflow-hidden",
+                div {
+                    class: "h-full bg-primary-text rounded",
+                    style: "width: {pct}%",
+                }
+            }
+            span { class: "text-secondary-text w-12 text-right", "{secs:.1}s" }
         }
     }
 }


### PR DESCRIPTION
Adds an event-driven debug panel (debug builds only) that visualises the three rotator queues, per-action condition/cooldown status, a scrollable timeline of Enqueued/Dispatched/Blocked events, and the player block reason in real time.

Backend:
- New rotator_debug.rs with RotatorDebugEvent, RotatorSnapshot, ActionView, PriorityActionView, BlockReason, CondOutcome, QueueKind, and a ring-buffer RotatorDebugSink (capacity 512, disabled by default)
- Embed sink.emit() calls in DefaultRotator at every condition evaluation, enqueue, dispatch, blocked, and normal-advance point
- build_snapshot() emits a full RotatorSnapshot on the first rotate tick after the panel is enabled, satisfying the "initial full state" requirement
- DebugService.broadcast_rotator_debug() drains dirty events and broadcasts them via a broadcast channel each services poll cycle
- Request/Response variants + public async helpers for RotatorDebugReceiver and SetRotatorDebugEnabled wired through the mediator

UI:
- RotatorDebugPanel Dioxus component with four sections: Queues (Priority / Side / Normal traversal), Conditions & Cooldown (progress bar per action), Timeline (ring-buffered, 200-entry, pauseable), Player State (block reason)
- Enable/Pause toggle buttons; panel is completely unmounted when disabled, producing zero per-tick overhead in the backend sink

Fixes:
- E0277: BuffKind has no Display; changed format string to {:?}
- E0502: debug block in rotate_priority_actions was reborrowing self.priority_actions immutably while a mutable borrow was still live; removed the redundant reborrow and reused the existing &mut PriorityAction
- Orphan rule: moved Default for BlockReason from ui crate to backend via #[derive(Default)] + #[default] on the None variant