### PR TITLE
feat: smoother rotation, configurable move tolerance, minimap circles…

### DIFF
--- a/backend/src/models/character.rs
+++ b/backend/src/models/character.rs
@@ -75,6 +75,9 @@ pub struct Character {
     #[serde(default)]
     pub disable_double_jumping: bool,
     pub disable_adjusting: bool,
+    /// Pixel tolerance for a non-exact (non-adjusting) move to count as arrived.
+    #[serde(default = "move_tolerance_default")]
+    pub move_tolerance: u32,
     #[serde(default)]
     pub disable_teleport_on_fall: bool,
     #[serde(default)]
@@ -143,6 +146,7 @@ impl Default for Character {
             link_key_timing_millis: 0,
             disable_double_jumping: false,
             disable_adjusting: false,
+            move_tolerance: move_tolerance_default(),
             disable_teleport_on_fall: false,
             disable_grapple_on_double_jumping: false,
             up_jump_is_flight: false,
@@ -161,6 +165,10 @@ fn feed_pet_count_default() -> u32 {
 
 fn hexa_booster_exchange_amount_default() -> u32 {
     1
+}
+
+fn move_tolerance_default() -> u32 {
+    5
 }
 
 fn jump_key_default() -> KeyBindingConfiguration {

--- a/backend/src/models/settings.rs
+++ b/backend/src/models/settings.rs
@@ -34,6 +34,8 @@ pub struct Settings {
     pub platform_end_key: KeyBindingConfiguration,
     #[serde(default = "platform_add_key_default")]
     pub platform_add_key: KeyBindingConfiguration,
+    #[serde(default = "action_move_add_key_default")]
+    pub action_move_add_key: KeyBindingConfiguration,
 }
 
 impl Default for Settings {
@@ -56,6 +58,7 @@ impl Default for Settings {
             platform_start_key: platform_start_key_default(),
             platform_end_key: platform_end_key_default(),
             platform_add_key: platform_add_key_default(),
+            action_move_add_key: action_move_add_key_default(),
         }
     }
 }
@@ -98,6 +101,13 @@ fn platform_end_key_default() -> KeyBindingConfiguration {
 fn platform_add_key_default() -> KeyBindingConfiguration {
     KeyBindingConfiguration {
         key: KeyBinding::L,
+        enabled: false,
+    }
+}
+
+fn action_move_add_key_default() -> KeyBindingConfiguration {
+    KeyBindingConfiguration {
+        key: KeyBinding::Semicolon,
         enabled: false,
     }
 }

--- a/backend/src/player/actions.rs
+++ b/backend/src/player/actions.rs
@@ -41,6 +41,7 @@ pub struct Key {
     pub wait_after_use_ticks: u32,
     pub wait_after_use_ticks_random_range: u32,
     pub wait_after_buffered: WaitAfterBuffered,
+    pub interruptible_by_priority: bool,
 }
 
 impl fmt::Display for Key {
@@ -98,6 +99,7 @@ impl From<ActionKey> for Key {
             wait_after_use_ticks,
             wait_after_use_ticks_random_range,
             wait_after_buffered,
+            interruptible_by_priority: false,
         }
     }
 }

--- a/backend/src/player/mod.rs
+++ b/backend/src/player/mod.rs
@@ -147,11 +147,11 @@ impl Player {
             | Player::Jumping(moving)
             | Player::UpJumping(UpJumping { moving, .. })
             | Player::Falling(Falling { moving, .. }) => moving.completed,
+            Player::UseKey(use_key) => use_key.interruptible_by_priority,
             Player::SolvingRune(_)
             | Player::CashShopThenExit(_)
             | Player::Unstucking(_)
             | Player::DoubleJumping(DoubleJumping { forced: true, .. })
-            | Player::UseKey(_)
             | Player::FamiliarsSwapping(_)
             | Player::Panicking(_)
             | Player::UsingBooster(_)
@@ -215,6 +215,11 @@ pub fn run_system(
     }
 
     if player.context.reset_to_idle_next_update {
+        if let Player::UseKey(use_key) = &player.state {
+            if use_key.interruptible_by_priority {
+                use_key.release_if_holding(resources);
+            }
+        }
         player.context.reset_to_idle_next_update = false;
         player.state = Player::Idle;
     }

--- a/backend/src/player/moving.rs
+++ b/backend/src/player/moving.rs
@@ -277,10 +277,12 @@ pub fn update_moving_state(
     let cur_pos = context.last_known_pos.unwrap();
     let moving = Moving::new(cur_pos, dest, exact, intermediates);
     let is_intermediate = moving.is_destination_intermediate();
-    let skip_destination = moving.auto_mob_can_skip_current_destination(context);
-
     let (x_distance, _) = moving.x_distance_direction_from(true, cur_pos);
     let (y_distance, y_direction) = moving.y_distance_direction_from(true, cur_pos);
+
+    let move_tolerance = context.config.move_tolerance;
+    let skip_destination = moving.auto_mob_can_skip_current_destination(context)
+        || (!exact && x_distance < move_tolerance && y_distance < move_tolerance);
 
     let disable_double_jumping = context.config.disable_double_jumping;
     let disable_adjusting = context.config.disable_adjusting;
@@ -302,9 +304,15 @@ pub fn update_moving_state(
         );
     }
 
+    // For non-exact moves, only fine-adjust X while it is outside the move tolerance, so the
+    // Y-axis movement (grapple/up jump/jump/fall) can begin as soon as X is within tolerance
+    // instead of waiting until X reaches the exact center. Clamp to ADJUSTING_MEDIUM_THRESHOLD
+    // so a small tolerance can't trigger a no-op walk (Adjusting can't walk below it).
+    let adjust_threshold = move_tolerance.max(ADJUSTING_MEDIUM_THRESHOLD);
+
     // Check to adjust and allow disabling adjusting only if `exact` is false
     if !skip_destination
-        && ((!disable_adjusting && x_distance >= ADJUSTING_MEDIUM_THRESHOLD)
+        && ((!disable_adjusting && x_distance >= adjust_threshold)
             || (exact && x_distance >= ADJUSTING_SHORT_THRESHOLD))
     {
         return abort_action_on_state_repeat(

--- a/backend/src/player/state.rs
+++ b/backend/src/player/state.rs
@@ -177,6 +177,8 @@ pub struct PlayerConfiguration {
     pub disable_double_jumping: bool,
     /// Whether to disable [`Player::Adjusting`].
     pub disable_adjusting: bool,
+    /// Pixel tolerance for considering a non-exact move as arrived (skips fine adjustment).
+    pub move_tolerance: i32,
     /// Whether to disable teleportation in [`Player::Falling`].
     pub disable_teleport_on_fall: bool,
     /// Whether to disable grappling in [`Player::DoubleJump`] when near the destination.
@@ -233,6 +235,7 @@ impl Default for PlayerConfiguration {
             has_extended_teleport_range: false,
             disable_double_jumping: false,
             disable_adjusting: false,
+            move_tolerance: 5,
             disable_teleport_on_fall: false,
             disable_grapple_on_double_jumping: false,
             up_jump_is_flight: false,

--- a/backend/src/player/use_key.rs
+++ b/backend/src/player/use_key.rs
@@ -83,6 +83,7 @@ pub struct UseKey {
     pending_transition: PendingTransition,
     action_info: Option<ActionInfo>,
     state: State,
+    pub(super) interruptible_by_priority: bool,
 }
 
 impl UseKey {
@@ -100,6 +101,7 @@ impl UseKey {
             wait_after_use_ticks,
             wait_after_use_ticks_random_range,
             wait_after_buffered,
+            interruptible_by_priority,
             ..
         } = key;
         let wait_before =
@@ -121,6 +123,7 @@ impl UseKey {
             pending_transition: PendingTransition::None,
             action_info: None,
             state: State::Precondition,
+            interruptible_by_priority,
         }
     }
 
@@ -148,6 +151,7 @@ impl UseKey {
             pending_transition: PendingTransition::None,
             action_info: Some(ActionInfo::AutoMobbing { should_terminate }),
             state: State::Precondition,
+            interruptible_by_priority: false,
         }
     }
 
@@ -181,6 +185,18 @@ impl UseKey {
             pending_transition: PendingTransition::None,
             action_info: None,
             state: State::Precondition,
+            interruptible_by_priority: false,
+        }
+    }
+
+    /// Releases the skill key if it is currently being held (during the `Using` phase).
+    ///
+    /// Called when this UseKey is interrupted by a priority action mid-hold.
+    pub(super) fn release_if_holding(&self, resources: &mut Resources) {
+        if matches!(self.state, State::Using(Using { hold_completed: false, .. }))
+            && self.key_hold_ticks > 0
+        {
+            resources.input.send_key_up(self.key);
         }
     }
 

--- a/backend/src/rotator.rs
+++ b/backend/src/rotator.rs
@@ -850,6 +850,10 @@ impl DefaultRotator {
         let debug_index = self.normal_index;
         self.normal_index = (self.normal_index + 1) % self.normal_actions.len();
         match action {
+            RotatorAction::Single(PlayerAction::Key(mut key)) => {
+                key.interruptible_by_priority = true;
+                player_context.set_normal_action(Some(id), PlayerAction::Key(key));
+            }
             RotatorAction::Single(action) => {
                 player_context.set_normal_action(Some(id), action);
             }
@@ -904,6 +908,10 @@ impl DefaultRotator {
 
         self.normal_index = (self.normal_index + 1) % len;
         match action {
+            RotatorAction::Single(PlayerAction::Key(mut key)) => {
+                key.interruptible_by_priority = true;
+                player_context.set_normal_action(Some(id), PlayerAction::Key(key));
+            }
             RotatorAction::Single(action) => {
                 player_context.set_normal_action(Some(id), action);
             }
@@ -1475,6 +1483,7 @@ fn familiar_essence_replenish_priority_action(key: KeyKind) -> PriorityAction {
             wait_after_use_ticks: 0,
             wait_after_use_ticks_random_range: 0,
             wait_after_buffered: WaitAfterBuffered::None,
+            interruptible_by_priority: false,
         })),
         queue_to_front: true,
         queue_info: PriorityActionQueueInfo::default(),
@@ -1677,6 +1686,7 @@ fn buff_priority_action(buff: BuffKind, key: KeyKind) -> PriorityAction {
             wait_after_use_ticks: 10,
             wait_after_use_ticks_random_range: 0,
             wait_after_buffered: WaitAfterBuffered::None,
+            interruptible_by_priority: false,
         })),
         metadata: Some(ActionMetadata::Buff { kind: buff }),
         queue_to_front: true,
@@ -1760,6 +1770,7 @@ fn elite_boss_use_key_priority_action(key: KeyKind) -> PriorityAction {
             wait_after_use_ticks: 10,
             wait_after_use_ticks_random_range: 0,
             wait_after_buffered: WaitAfterBuffered::None,
+            interruptible_by_priority: false,
         })),
         metadata: None,
         queue_to_front: true,

--- a/backend/src/services/character.rs
+++ b/backend/src/services/character.rs
@@ -36,6 +36,7 @@ impl CharacterService for DefaultCharacterService {
                 character.has_extended_teleport_range;
             player_context.config.disable_double_jumping = character.disable_double_jumping;
             player_context.config.disable_adjusting = character.disable_adjusting;
+            player_context.config.move_tolerance = character.move_tolerance as i32;
             player_context.config.disable_teleport_on_fall = character.disable_teleport_on_fall;
             player_context.config.disable_grapple_on_double_jumping =
                 character.disable_grapple_on_double_jumping;
@@ -170,6 +171,10 @@ mod tests {
             character.disable_double_jumping
         );
         assert_eq!(state.config.disable_adjusting, character.disable_adjusting);
+        assert_eq!(
+            state.config.move_tolerance,
+            character.move_tolerance as i32
+        );
         assert_eq!(
             state.config.disable_teleport_on_fall,
             character.disable_teleport_on_fall

--- a/ui/src/actions/mod.rs
+++ b/ui/src/actions/mod.rs
@@ -1,8 +1,12 @@
 use std::{collections::HashMap, fmt::Display, mem::discriminant};
 
-use backend::{Action, ActionCondition, IntoEnumIterator, KeyBinding, Map, update_map, upsert_map};
+use backend::{
+    Action, ActionCondition, ActionMove, IntoEnumIterator, KeyBinding, Map, Position, key_receiver,
+    update_map, upsert_map,
+};
 use dioxus::prelude::*;
 use futures_util::StreamExt;
+use tokio::sync::broadcast::error::RecvError;
 use inner::SectionActions;
 use platforms::SectionPlatforms;
 use rotation::SectionRotation;
@@ -154,6 +158,44 @@ pub fn ActionsScreen() -> Element {
 
         map_preset.set(Some(selected));
         coroutine.send(ActionsUpdate::Set);
+    });
+
+    // Hotkey: append a normal Move action at the current player position to the selected
+    // preset. Mirrors the platform add hotkey in `SectionPlatforms`.
+    let settings = use_context::<AppState>().settings;
+    let position = use_context::<AppState>().position;
+    use_future(move || async move {
+        let mut key_receiver = key_receiver().await;
+        loop {
+            let key = match key_receiver.recv().await {
+                Ok(value) => value,
+                Err(RecvError::Closed) => break,
+                Err(RecvError::Lagged(_)) => continue,
+            };
+            let Some(settings) = &*settings.peek() else {
+                continue;
+            };
+            if !settings.action_move_add_key.enabled || settings.action_move_add_key.key != key {
+                continue;
+            }
+            if map_preset.peek().is_none() {
+                continue;
+            }
+
+            let (x, y) = *position.peek();
+            let mut actions = map_preset_actions.peek().clone();
+            actions.push(Action::Move(ActionMove {
+                position: Position {
+                    x,
+                    x_random_range: 0,
+                    y,
+                    allow_adjusting: false,
+                },
+                condition: ActionCondition::Any,
+                wait_after_move_millis: 0,
+            }));
+            coroutine.send(ActionsUpdate::Update(actions));
+        }
     });
 
     let lists = use_signal::<HashMap<String, ActionCondition>>(HashMap::default);

--- a/ui/src/characters/mod.rs
+++ b/ui/src/characters/mod.rs
@@ -552,6 +552,19 @@ fn SectionMovement() -> Element {
                     tooltip: "Not applicable if an action requires adjusting.",
                     disabled,
                 }
+                CharactersNumberU32Input {
+                    label: "Move tolerance",
+                    value: character().move_tolerance,
+                    max_value: 50,
+                    tooltip: "Pixel radius for considering a move as arrived. Values above 25 for normal classes or 12 for mages may cause movement issues, as the character may double jump within the tolerance instead of moving along the Y axis.",
+                    on_value: move |move_tolerance| {
+                        save_character(Character {
+                            move_tolerance,
+                            ..character.peek().clone()
+                        });
+                    },
+                    disabled: disabled(),
+                }
             }
         }
     }
@@ -920,10 +933,17 @@ fn CharactersNumberU32Input(
     value: u32,
     on_value: Callback<u32>,
     #[props(default)] max_value: Option<u32>,
+    #[props(default)] tooltip: Option<String>,
+    #[props(default = ContentSide::Top)] tooltip_side: ContentSide,
+    #[props(default = ContentAlign::Center)] tooltip_align: ContentAlign,
     #[props(default)] disabled: bool,
 ) -> Element {
     rsx! {
-        Labeled { label,
+        Labeled {
+            label,
+            tooltip,
+            tooltip_side,
+            tooltip_align,
             PrimitiveIntegerInput {
                 value,
                 on_value,

--- a/ui/src/debug.rs
+++ b/ui/src/debug.rs
@@ -105,8 +105,8 @@ pub fn DebugScreen() -> Element {
                     }
                 }
             }
+            RotatorDebugPanel {}
         }
-        RotatorDebugPanel {}
     }
 }
 

--- a/ui/src/minimap.rs
+++ b/ui/src/minimap.rs
@@ -34,6 +34,8 @@ const MINIMAP_JS: &str = r#"
 
     while (true) {
         const [buffer, width, height, destinations, bound, quadrant, portals, rune, playerPosition] = await dioxus.recv();
+        canvas.width = width;
+        canvas.height = height;
         const data = new ImageData(new Uint8ClampedArray(buffer), width, height);
         const bitmap = await createImageBitmap(data);
 
@@ -171,11 +173,12 @@ const MINIMAP_JS: &str = r#"
 const MINIMAP_ACTIONS_JS: &str = r#"
     const canvas = document.getElementById("canvas-map-actions");
     const canvasCtx = canvas.getContext("2d");
-    const [width, height, actions, boundAndType, platforms] = await dioxus.recv();
+    const [width, height, actions, boundAndType, platforms, radius] = await dioxus.recv();
+    canvas.width = width;
+    canvas.height = height;
     canvasCtx.clearRect(0, 0, canvas.width, canvas.height);
-    const anyActions = actions.filter((action) => action.condition === "Any");
-    const erdaActions = actions.filter((action) => action.condition === "ErdaShowerOffCooldown");
-    const millisActions = actions.filter((action) => action.condition === "EveryMillis");
+    const moveActions = actions.filter((action) => action.action_type === "move");
+    const keyActions = actions.filter((action) => action.action_type === "key");
 
     drawBound(canvasCtx, boundAndType);
 
@@ -191,18 +194,10 @@ const MINIMAP_ACTIONS_JS: &str = r#"
         canvasCtx.stroke();
     }
 
-    canvasCtx.setLineDash([8]);
-    canvasCtx.fillStyle = "rgb(255, 153, 128)";
-    canvasCtx.strokeStyle = "rgb(255, 153, 128)";
-    drawActions(canvas, canvasCtx, anyActions, true);
-
-    canvasCtx.fillStyle = "rgb(179, 198, 255)";
-    canvasCtx.strokeStyle = "rgb(179, 198, 255)";
-    drawActions(canvas, canvasCtx, erdaActions, true);
-
-    canvasCtx.fillStyle = "rgb(128, 255, 204)";
-    canvasCtx.strokeStyle = "rgb(128, 255, 204)";
-    drawActions(canvas, canvasCtx, millisActions, false);
+    // Move actions: blue thick circle with connecting arcs
+    drawPositionActions(canvas, canvasCtx, moveActions, "rgb(79, 195, 247)", 3, true, radius);
+    // Key+position actions: yellow circle, no arcs
+    drawPositionActions(canvas, canvasCtx, keyActions, "rgb(255, 224, 130)", 2, false, radius);
 
     function drawBound(canvasCtx, boundAndType) {
         if (boundAndType === null) {
@@ -259,32 +254,37 @@ const MINIMAP_ACTIONS_JS: &str = r#"
         canvasCtx.stroke();
     }
 
-    function drawActions(canvas, ctx, actions, hasArc) {
-        const rectSize = 4;
-        const rectHalf = rectSize / 2;
+    function drawPositionActions(canvas, ctx, actions, color, lineWidth, hasArc, radius) {
         let lastAction = null;
         let i = 1;
 
-        ctx.font = '12px sans-serif';
+        ctx.font = 'bold 10px sans-serif';
+        ctx.fillStyle = color;
+        ctx.strokeStyle = color;
+        ctx.lineWidth = lineWidth;
 
         for (const action of actions) {
             const x = (action.x / width) * canvas.width;
             const y = ((height - action.y) / height) * canvas.height;
 
-            ctx.fillRect(x, y, rectSize, rectSize);
+            ctx.setLineDash([]);
+            ctx.beginPath();
+            ctx.arc(x, y, radius, 0, 2 * Math.PI);
+            ctx.stroke();
 
-            let labelX = x + rectSize / 2;
-            let labelY = y + rectSize - 7;
-            ctx.fillText(i, labelX, labelY);
+            ctx.fillText(i, x + radius + 2, y + 4);
 
             if (hasArc && lastAction !== null) {
                 let [fromX, fromY] = lastAction;
-                drawArc(ctx, fromX + rectHalf, fromY + rectHalf, x + rectHalf, y + rectHalf);
+                ctx.setLineDash([4, 4]);
+                drawArc(ctx, fromX, fromY, x, y);
             }
 
             lastAction = [x, y];
             i++;
         }
+        ctx.lineWidth = 1;
+        ctx.setLineDash([]);
     }
     function drawArc(ctx, fromX, fromY, toX, toY) {
         const cx = (fromX + toX) / 2;
@@ -305,6 +305,7 @@ struct ActionView {
     x: i32,
     y: i32,
     condition: String,
+    action_type: String,
 }
 
 #[derive(PartialEq, Clone, Debug)]
@@ -509,7 +510,25 @@ fn Canvas(
         }
     });
 
+    // Tracks the actual captured minimap pixel dimensions for 1:1 display.
+    let mut minimap_size = use_signal(|| Option::<(usize, usize)>::None);
+
+    // Action circle radius (in minimap pixels) = the selected character's move tolerance, so
+    // the drawn circle visually matches the movement arrival zone. Defaults to 5 when no
+    // character is selected. The memo dedupes, so the actions effect only re-runs on change.
+    let character = use_context::<AppState>().character;
+    let move_tolerance = use_memo(move || character().map(|c| c.move_tolerance).unwrap_or(5));
+
     use_effect(move || {
+        // Use the live detected frame dimensions, NOT the saved map.width/height (which can
+        // be 0 and would collapse the canvas to 0x0 / produce NaN coordinates). This also
+        // keeps the actions canvas perfectly aligned with the background canvas, which is
+        // sized from the same frame. Re-runs when the size changes so circles (re)draw once
+        // the minimap appears.
+        let Some((width, height)) = minimap_size() else {
+            return;
+        };
+        let radius = move_tolerance();
         let bound_and_type = rotation_bound_and_type();
         let preset = map_preset();
         let Some(map) = map() else {
@@ -524,8 +543,13 @@ fn Canvas(
                     position: Position { x, y, .. },
                     condition,
                     ..
-                })
-                | Action::Key(ActionKey {
+                }) => Some(ActionView {
+                    x,
+                    y,
+                    condition: condition.to_string(),
+                    action_type: "move".to_string(),
+                }),
+                Action::Key(ActionKey {
                     position: Some(Position { x, y, .. }),
                     condition,
                     ..
@@ -533,6 +557,7 @@ fn Canvas(
                     x,
                     y,
                     condition: condition.to_string(),
+                    action_type: "key".to_string(),
                 }),
                 _ => None,
             })
@@ -541,11 +566,12 @@ fn Canvas(
         spawn(async move {
             let canvas = document::eval(MINIMAP_ACTIONS_JS);
             let _ = canvas.send((
-                map.width,
-                map.height,
+                width,
+                height,
                 actions,
                 bound_and_type,
                 map.platforms,
+                radius,
             ));
         });
     });
@@ -588,8 +614,14 @@ fn Canvas(
                 .deref()
                 .map(|(bound, _)| bound);
             let Some((frame, width, height)) = frame else {
+                if minimap_size.peek().is_some() {
+                    minimap_size.set(None);
+                }
                 continue;
             };
+            if *minimap_size.peek() != Some((width, height)) {
+                minimap_size.set(Some((width, height)));
+            }
             let Err(error) =
                 canvas.send((frame, width, height, destinations, bound, quadrant, portals, rune, player_position))
             else {
@@ -602,15 +634,40 @@ fn Canvas(
         }
     });
 
+    let (canvas_w, canvas_h) = minimap_size().unwrap_or((0, 0));
+    let has_minimap = canvas_w > 0 && canvas_h > 0;
+    // Inline styles (not utility classes) for the critical constraints:
+    // min-width:0 lets this flex child shrink below content width; max-width:100% keeps it
+    // within the 320px panel; overflow:auto scrolls a larger map instead of spilling onto
+    // the Tabs nav to the right; max-height caps vertical growth.
+    // h-24 isn't compiled in tailwind.css, so set the height inline as well.
+    let placeholder_style = if has_minimap {
+        "display: none;".to_string()
+    } else {
+        "height: 6rem; color: var(--color-muted-foreground, #6b7280);".to_string()
+    };
     rsx! {
-        div { class: "relative h-31 rounded-2xl bg-secondary-surface",
-            canvas {
-                class: "absolute inset-0 rounded-2xl w-full h-full",
-                id: "canvas-map",
+        div {
+            class: "rounded-2xl bg-secondary-surface",
+            style: "min-width: 0; max-width: 100%; max-height: 13rem; overflow: auto;",
+            // Placeholder is kept in the DOM (toggled via display) so the canvases below are
+            // never reconciled away — removing a sibling would wipe their drawn bitmaps.
+            div {
+                class: "flex items-center justify-center text-sm rounded-2xl",
+                style: "{placeholder_style}",
+                "No minimap detected"
             }
-            canvas {
-                class: "absolute inset-0 rounded-2xl w-full h-full",
-                id: "canvas-map-actions",
+            // Real-pixel-size content box; the two canvases stack via absolute positioning.
+            div {
+                style: "position: relative; width: {canvas_w}px; height: {canvas_h}px;",
+                canvas {
+                    id: "canvas-map",
+                    style: "position: absolute; top: 0; left: 0; width: {canvas_w}px; height: {canvas_h}px; border-radius: 1rem;",
+                }
+                canvas {
+                    id: "canvas-map-actions",
+                    style: "position: absolute; top: 0; left: 0; width: {canvas_w}px; height: {canvas_h}px; border-radius: 1rem;",
+                }
             }
         }
     }

--- a/ui/src/settings.rs
+++ b/ui/src/settings.rs
@@ -437,6 +437,16 @@ fn SectionHotkeys() -> Element {
                     },
                     value: settings().platform_end_key,
                 }
+                Hotkey {
+                    label: "Add move action",
+                    on_value: move |action_move_add_key| {
+                        save_settings(Settings {
+                            action_move_add_key,
+                            ..settings.peek().clone()
+                        });
+                    },
+                    value: settings().action_move_add_key,
+                }
             }
         }
     }


### PR DESCRIPTION
… & add-move hotkey

Several related rotator/movement/minimap improvements:

Rotator smoothness:
- Add `interruptible_by_priority` to NA-origin UseKey so Every-millisecond priority actions (EA) can interrupt a normal UseKey instead of waiting for it to finish. Held keys are released cleanly on interrupt.

Movement tolerance:
- Add a per-character `move_tolerance` (default 5), configurable under Characters > Movement, replacing the hardcoded arrival tolerance.
- For non-exact moves, gate X fine-adjustment on `move_tolerance` so Y-axis movement begins once X is within tolerance, instead of only at the exact center. Exact (Adjust) actions still align to 1px.
- Tooltip warns that tolerance above the double-jump threshold (25 normal / 12 mage) can cause movement issues.

Minimap:
- Preserve the captured minimap's real pixel size with scroll when larger than the panel; show a placeholder when no minimap is detected (fixes the grey/clipped minimap and overflow onto the nav).
- Draw normal actions as circles (Move = blue, positioned Key = yellow); circle radius follows `move_tolerance`. Sized/normalized against the live detected frame so circles render even when the saved map size is 0.

Actions:
- Add an "Add move action" hotkey that appends a Move action at the current player position to the selected preset.